### PR TITLE
Add a return parameter to the post function

### DIFF
--- a/MGInstagram/MGInstagram.h
+++ b/MGInstagram/MGInstagram.h
@@ -29,9 +29,9 @@ extern NSString* const kInstagramOnlyPhotoFileName;
 
 ///post image to instagram by passing in the target image and
 ///the view in which the user will be presented with the instagram model
-- (void)postImage:(UIImage*)image inView:(UIView*)view;
+- (BOOL)postImage:(UIImage*)image inView:(UIView*)view;
 ///Same as above method but with the option for a photo caption
-- (void)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view;
-- (void)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view delegate:(id<UIDocumentInteractionControllerDelegate>)delegate;
+- (BOOL)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view;
+- (BOOL)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view delegate:(id<UIDocumentInteractionControllerDelegate>)delegate;
 
 @end

--- a/MGInstagram/MGInstagram.m
+++ b/MGInstagram/MGInstagram.m
@@ -42,18 +42,19 @@ NSString* const kInstagramOnlyPhotoFileName = @"tempinstgramphoto.igo";
     return [NSString stringWithFormat:@"%@/%@",[NSHomeDirectory() stringByAppendingPathComponent:@"Documents"],self.photoFileName];
 }
 
-- (void)postImage:(UIImage*)image inView:(UIView*)view {
-    [self postImage:image withCaption:nil inView:view];
-}
-- (void)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view {
-    [self postImage:image withCaption:caption inView:view delegate:nil];
+- (BOOL)postImage:(UIImage*)image inView:(UIView*)view {
+    return [self postImage:image withCaption:nil inView:view];
 }
 
-- (void)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view delegate:(id<UIDocumentInteractionControllerDelegate>)delegate {
+- (BOOL)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view {
+    return [self postImage:image withCaption:caption inView:view delegate:nil];
+}
+
+- (BOOL)postImage:(UIImage*)image withCaption:(NSString*)caption inView:(UIView*)view delegate:(id<UIDocumentInteractionControllerDelegate>)delegate {
     NSParameterAssert(image);
     
     if (!image) {
-        return;
+        return NO;
     }
     
     [UIImageJPEGRepresentation(image, 1.0) writeToFile:[self photoFilePath] atomically:YES];
@@ -65,7 +66,7 @@ NSString* const kInstagramOnlyPhotoFileName = @"tempinstgramphoto.igo";
     if (caption) {
         self.documentInteractionController.annotation = @{@"InstagramCaption" : caption};
     }
-    [self.documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:view animated:YES];
+    return [self.documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:view animated:YES];
 }
 
 


### PR DESCRIPTION
If the system is not able to present the document interaction controller,
the presentOpen method will return false. This result has been added
as the return value of the post method so that the calling app knows the
result and can handle the case appropriately.

My app was rejected by App Review because on their test device (iPad), Instagram was not installed and the document controller was not showing. 